### PR TITLE
Add link to git-submodules manager

### DIFF
--- a/src/user/managers.md
+++ b/src/user/managers.md
@@ -15,3 +15,7 @@ lockfile.
 ## Docker
 
 - [dockerfile](https://docs.renovatebot.com/modules/manager/dockerfile/)
+
+## Git Submodules
+
+- [git-submodules](https://docs.renovatebot.com/modules/manager/git-submodules/)


### PR DESCRIPTION
Can be merged after https://github.com/redhat-appstudio/infra-deployments/pull/4035 .